### PR TITLE
Updated CI workflow for testing on Pharo 13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        smalltalk: [Pharo64-10, Pharo64-11, Pharo64-12, Squeak64-6.0]
+        smalltalk:
+          [Pharo64-10, Pharo64-11, Pharo64-12, Pharo64-13, Squeak64-6.0]
         experimental: [false]
     continue-on-error: ${{ matrix.experimental }}
     name: ${{ matrix.smalltalk }}

--- a/repository/BaselineOfSIXX.package/BaselineOfSIXX.class/instance/baseline..st
+++ b/repository/BaselineOfSIXX.package/BaselineOfSIXX.class/instance/baseline..st
@@ -33,7 +33,7 @@ baseline: spec
 		spec package: 'SIXX-InOut-Common' with: [spec includes: 'SIXX-InOut-Pharo'].
 		spec package: 'SIXX-InOut-Pharo' with: [spec requires: #('SIXX-Pharo' 'SIXX-InOut-Common')].
 	].
-	spec for: #(#'pharo11.x' #'pharo12.x') do:[
+	spec for: #(#'pharo11.x' #'pharo12.x' #'pharo13.x') do:[
 		spec package: 'SIXX-InOut-Common' with: [spec includes: 'SIXX-InOut-Pharo110'].
 		spec package: 'SIXX-InOut-Pharo110' with: [spec requires: #('SIXX-Pharo' 'SIXX-InOut-Common')].
 	].


### PR DESCRIPTION
This pull request introduces support for Pharo 13 across the project by updating the CI workflow and the baseline configuration. The changes ensure that the project is compatible with the latest version of Pharo while maintaining support for existing versions.

### Updates for Pharo 13 support:

* **CI Workflow Update**: Added `Pharo64-13` to the matrix of Smalltalk versions in the GitHub Actions workflow file `.github/workflows/main.yml`, enabling automated testing for Pharo 13.
* **Baseline Configuration Update**: Extended the baseline configuration in `repository/BaselineOfSIXX.package/BaselineOfSIXX.class/instance/baseline..st` to include support for Pharo 13 by adding `#'pharo13.x'` to the relevant specification.